### PR TITLE
Chore: save log as file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ __pycache__/
 # Secret files
 /clone_twitter/secrets.json
 
+# Logging
+/clone_twitter/logging
+
 # Static files
 /clone_twitter/static/
 

--- a/clone_twitter/twitter/settings.py
+++ b/clone_twitter/twitter/settings.py
@@ -198,3 +198,63 @@ JWT_AUTH = {
 AUTH_USER_MODEL = 'user.User'
 
 SITE_ID = 1
+
+#CUSTOM LOGGING
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse',
+        },
+        'require_debug_true': {
+            '()': 'django.utils.log.RequireDebugTrue',
+        },
+    },
+    'formatters': {
+        'django.server': {
+            '()': 'django.utils.log.ServerFormatter',
+            'format': '[{server_time}] {message}',
+            'style': '{',
+        }
+    },
+    'handlers': {
+        'console': {
+            'level': 'INFO',
+            'filters': ['require_debug_true'],
+            'class': 'logging.StreamHandler',
+        },
+        'django.server': {
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
+            'formatter': 'django.server',
+        },
+        'mail_admins': {
+            'level': 'ERROR',
+            'filters': ['require_debug_false'],
+            'class': 'django.utils.log.AdminEmailHandler'
+        },
+        # added for saving log files
+        'file': {
+            'level': 'DEBUG',
+            'filters': ['require_debug_true'],  # later change to debug_false (only for server)
+            'class': 'logging.handlers.RotatingFileHandler',
+            'formatter': 'django.server',
+            'encoding': 'UTF-8',
+            'filename': os.path.join(BASE_DIR, 'logging/clonetwitter.log'),
+            'maxBytes': 1024 * 1024 * 5,  # 5 MB
+            'backupCount': 5,
+        },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console', 'mail_admins', 'file'],
+            # 'level': 'INFO',
+        },
+        'django.server': {
+            'handlers': ['django.server'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+    }
+}

--- a/clone_twitter/user/views.py
+++ b/clone_twitter/user/views.py
@@ -175,11 +175,16 @@ class KakaoCallbackView(APIView):
         }
         response = requests.post(kakao_token_url, data=data).json()
         access_token = response.get("access_token")
+        if not access_token:
+            return Response(status=status.HTTP_400_BAD_REQUEST, data={'message': 'failed to get access_token'})
 
         # 2. get user information
         user_info_url = "https://kapi.kakao.com/v2/user/me"
         user_info_response = requests.get(user_info_url, headers={"Authorization": f"Bearer ${access_token}"},).json()
         kakao_id = user_info_response.get("id")
+        if not kakao_id:
+            return Response(status=status.HTTP_400_BAD_REQUEST, data={'message': 'failed to get kakao_id'})
+
         # TODO: are you going to get user profile, too???
 
         # 3. connect kakao account - user


### PR DESCRIPTION
서버에서 에러가 났을 경우 로컬처럼 터미널에서 디버깅 정보를 확인하기 어려워 파일로 로그를 저장하는 걸 추가했습니다. log 파일을 저장할 디렉토리는 `.gitignore`에 설정하였기에 머지 후 직접 서버 인스턴스 접속해서 디렉토리 생성할 예정입니다. 일단 제 필요에 맞게 설정을 임의로 한 셈이라, (나중에 배포는 debug=false 로 변경하면 수정되어야 할 부분도 있습니다) 세부적으로 원하시는 설정 있으시다면 [공식문서](https://docs.djangoproject.com/en/4.0/topics/logging/) 참고하시고 반영하시면 됩니다! 

(+ error handler 관련 좋은 자료 공유해주셨는데.. 이 방법으로 로컬에서 runserver했을 때 뜨던 debug 단계의 정보까지 가져오는 법을 모르겠어서 `settings.py` 의 로깅 설정을 만지는 쪽으로 해결했습니다 ㅜㅜ) 
