### PR TITLE
Fix: Seperate Written Tweets and Retweets in User Info

### DIFF
--- a/clone_twitter/tweet/tests.py
+++ b/clone_twitter/tweet/tests.py
@@ -958,9 +958,9 @@ class GetSearchTweetTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # print(list(map(lambda x:x['author']['user_id'], response.json())))
-        self.assertEqual(list(map(lambda x:x['author']['user_id'], response.json())),
+        self.assertEqual(list(map(lambda x:x['author']['user_id'], response.json()['results'])),
         ['test9', 'test8ee', 'test7', 'test6', 'test5', 'test4', 'test3', 'test2'])
-        self.assertEqual(list(map(lambda x:x['tweet_type'], response.json())),
+        self.assertEqual(list(map(lambda x:x['tweet_type'], response.json()['results'])),
         ['GENERAL', 'GENERAL', 'GENERAL', 'GENERAL', 'GENERAL', 'GENERAL', 'GENERAL', 'GENERAL'])
 
     def test_get_search_latest(self):
@@ -973,9 +973,9 @@ class GetSearchTweetTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # print(list(map(lambda x:x['author']['user_id'], response.json())))
-        self.assertEqual(list(map(lambda x:x['author']['user_id'], response.json())),
+        self.assertEqual(list(map(lambda x:x['author']['user_id'], response.json()['results'])),
         ['test9', 'test6', 'test3', 'test7', 'test4', 'test8ee', 'test3', 'test3', 'test4', 'test5', 'test2', 'test1'])
-        self.assertEqual(list(map(lambda x:x['tweet_type'], response.json())),
+        self.assertEqual(list(map(lambda x:x['tweet_type'], response.json()['results'])),
         ['GENERAL', 'GENERAL', 'REPLY', 'GENERAL', 'REPLY', 'GENERAL', 'REPLY', 'GENERAL', 'GENERAL', 'GENERAL', 'GENERAL', 'GENERAL'])
 
 class QuoteTestCase(TestCase):

--- a/clone_twitter/tweet/tests.py
+++ b/clone_twitter/tweet/tests.py
@@ -957,7 +957,7 @@ class GetSearchTweetTestCase(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        print(list(map(lambda x:x['author']['user_id'], response.json())))
+        # print(list(map(lambda x:x['author']['user_id'], response.json())))
         self.assertEqual(list(map(lambda x:x['author']['user_id'], response.json())),
         ['test9', 'test8ee', 'test7', 'test6', 'test5', 'test4', 'test3', 'test2'])
         self.assertEqual(list(map(lambda x:x['tweet_type'], response.json())),
@@ -972,7 +972,7 @@ class GetSearchTweetTestCase(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        print(list(map(lambda x:x['author']['user_id'], response.json())))
+        # print(list(map(lambda x:x['author']['user_id'], response.json())))
         self.assertEqual(list(map(lambda x:x['author']['user_id'], response.json())),
         ['test9', 'test6', 'test3', 'test7', 'test4', 'test8ee', 'test3', 'test3', 'test4', 'test5', 'test2', 'test1'])
         self.assertEqual(list(map(lambda x:x['tweet_type'], response.json())),

--- a/clone_twitter/user/tests.py
+++ b/clone_twitter/user/tests.py
@@ -323,7 +323,6 @@ class GetFollowListTestCase(TestCase):
             content_type='application/json',
             HTTP_AUTHORIZATION=self.user1_token)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        #print(response.json())
 
     def test_get_following_success(self):
         response = self.client.get(
@@ -332,7 +331,6 @@ class GetFollowListTestCase(TestCase):
             content_type='application/json',
             HTTP_AUTHORIZATION=self.user1_token)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        #print(response.json())
 
 class GetRecommendTestCase(TestCase):
 
@@ -705,8 +703,6 @@ class GetUserTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         
         data = response.json()
-        print(data['tweets_written'])
-        print(data['tweets_retweeted'])
 
         self.assertEqual(data['username'], self.static_response_user2['username'])
         self.assertEqual(data['user_id'], self.static_response_user2['user_id'])
@@ -885,9 +881,5 @@ class GetSearchPeopleTestCase(TestCase):
             HTTP_AUTHORIZATION=self.tokens[0])
         
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        
-        # for k in response.json():
-        #    print(k)
-        # print(list(map(lambda x:x['user_id'], response.json())))
         self.assertEqual(list(map(lambda x:x['user_id'], response.json())),
         ['test9', 'test8ee', 'test7', 'test6', 'test5', 'test4', 'test3', 'test2', 'test1'])

--- a/clone_twitter/user/tests.py
+++ b/clone_twitter/user/tests.py
@@ -850,9 +850,9 @@ class GetSearchPeopleTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
 
-        user_id_list = ['test0', 'test1', 'test2', 'test3', 'test4', 'test5', 'test6', 'test7', 'test8ee', 'test9']
-        username_list = ['f', 'f', 'f', 'aa', 'aabb', 'aabbcc', 'aabbcc', 'aabbcc', 'aabbcc', 'aabbcc']
-        bio_list = ['', 'aa', 'aabbcc', 'mol', '?', 'ru', '', 'aaccdd', 'aa', 'aabbccddee']
+        user_id_list = ['test0', 'test1', 'test2', 'test3', 'test4', 'test5', 'test6', 'test7', 'test8ee', 'test9', 'kk', 'tt']
+        username_list = ['f', 'aa', 'f', 'aa', 'aabb', 'aabbcc', 'aabbcc', 'aabbcc', 'aabbcc', 'aabbcc', 'ee', 'gg']
+        bio_list = ['', '', 'aabbcc', 'mol', '?', 'ru', '', 'aaccdd', 'aa', 'aabbccddee', '', '']
         follow_relation = [(0,8), (1,8), (0,6)]
         
         cls.users = [
@@ -881,5 +881,17 @@ class GetSearchPeopleTestCase(TestCase):
             HTTP_AUTHORIZATION=self.tokens[0])
         
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(list(map(lambda x:x['user_id'], response.json())),
-        ['test9', 'test8ee', 'test7', 'test6', 'test5', 'test4', 'test3', 'test2', 'test1'])
+        self.assertEqual(list(map(lambda x:x['user_id'], response.json()['results'])),
+        ['test9', 'test8ee', 'test7', 'test6', 'test5', 'test4', 'test3', 'test2', 'kk', 'test1'])
+
+    # Several Keywords with those including @ sign
+    def test_get_search_people_with_atsign(self):
+        response = self.client.get(                            
+            '/api/v1/search/people/',
+            {'query': 'bb cc  aa dd @kk @tt ee'},
+            content_type='application/json',
+            HTTP_AUTHORIZATION=self.tokens[0])
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(list(map(lambda x:x['user_id'], response.json()['results'])),
+        ['kk', 'tt', 'test9', 'test8ee', 'test7', 'test6', 'test5', 'test4', 'test3', 'test2', 'test1'])

--- a/clone_twitter/user/tests.py
+++ b/clone_twitter/user/tests.py
@@ -610,32 +610,32 @@ class GetUserTestCase(TestCase):
         cls.tweet1 = TweetFactory(
             tweet_type = 'GENERAL',
             author = cls.user1,
-            content = 'content'
+            content = 'content1'
         )
 
         cls.tweet2 = TweetFactory(
             tweet_type = 'GENERAL',
             author = cls.user1,
-            content = 'content'
+            content = 'content2'
         )
 
         cls.tweet3 = TweetFactory(
             tweet_type = 'GENERAL',
             author = cls.user3,
-            content = 'content'
+            content = 'content3'
         )
 
         cls.tweet4 = TweetFactory(
             tweet_type = 'RETWEET',
             author = cls.user3,
-            retweeting_user = 'user2_id',
-            content = 'content'
+            retweeting_user = 'user1_id',
+            content = 'content3'
         )
 
         cls.retweet = RetweetFactory(
             retweeted = cls.tweet3,
             retweeting = cls.tweet4,
-            user = cls.user2
+            user = cls.user1
         )
         
         cls.static_response_user1 = {
@@ -643,9 +643,8 @@ class GetUserTestCase(TestCase):
             'user_id': 'user1_id',
             'bio': 'I am User 1.',
             'birth_date': '2002-11-15',
-            'tweets_written': 2,
-            'tweets_retweeted': 0,
-            'tweets_num': 2,
+            'tweets': ['content3', 'content2', 'content1'],
+            'tweets_num': 3,
             'following': 2,
             'follower': 0
         }
@@ -655,8 +654,7 @@ class GetUserTestCase(TestCase):
             'user_id': 'user2_id',
             'bio': '',
             'birth_date': None,
-            'tweets_written': 0,
-            'tweets_retweeted': 1,
+            'tweets': [],
             'tweets_num': 0,
             'following': 0,
             'follower': 1
@@ -688,8 +686,7 @@ class GetUserTestCase(TestCase):
         self.assertEqual(data['bio'], self.static_response_user1['bio'])
         self.assertIn("created_at", data)
         self.assertEqual(data['birth_date'], self.static_response_user1['birth_date'])
-        self.assertEqual(len(data['tweets_written'])-1, self.static_response_user1['tweets_written'])
-        self.assertEqual(len(data['tweets_retweeted'])-1, self.static_response_user1['tweets_retweeted'])
+        self.assertEqual(list(map(lambda x: x['content'], data['tweets'][:-1])), self.static_response_user1['tweets'])
         self.assertEqual(data['tweets_num'], self.static_response_user1['tweets_num'])
         self.assertEqual(data['following'], self.static_response_user1['following'])
         self.assertEqual(data['follower'], self.static_response_user1['follower'])
@@ -709,8 +706,7 @@ class GetUserTestCase(TestCase):
         self.assertEqual(data['bio'], self.static_response_user2['bio'])
         self.assertIn("created_at", data)
         self.assertEqual(data['birth_date'], self.static_response_user2['birth_date'])
-        self.assertEqual(len(data['tweets_written'])-1, self.static_response_user2['tweets_written'])
-        self.assertEqual(len(data['tweets_retweeted'])-1, self.static_response_user2['tweets_retweeted'])
+        self.assertEqual(list(map(lambda x: x['content'], data['tweets'][:-1])), self.static_response_user2['tweets'])
         self.assertEqual(data['tweets_num'], self.static_response_user2['tweets_num'])
         self.assertEqual(data['following'], self.static_response_user2['following'])
         self.assertEqual(data['follower'], self.static_response_user2['follower'])
@@ -729,8 +725,7 @@ class GetUserTestCase(TestCase):
         self.assertEqual(data['bio'], self.static_response_user1['bio'])
         self.assertIn("created_at", data)
         self.assertEqual(data['birth_date'], self.static_response_user1['birth_date'])
-        self.assertEqual(len(data['tweets_written'])-1, self.static_response_user1['tweets_written'])
-        self.assertEqual(len(data['tweets_retweeted'])-1, self.static_response_user1['tweets_retweeted'])
+        self.assertEqual(list(map(lambda x: x['content'], data['tweets'][:-1])), self.static_response_user1['tweets'])
         self.assertEqual(data['tweets_num'], self.static_response_user1['tweets_num'])
         self.assertEqual(data['following'], self.static_response_user1['following'])
         self.assertEqual(data['follower'], self.static_response_user1['follower'])
@@ -755,6 +750,7 @@ class PatchUserIDTestCase(TestCase):
             'user_id': 'user1',
             'bio': 'I am User 1.',
             'birth_date': '2002-11-15',
+            'tweets': [],
             'tweets_num': 0,
             'following': 0,
             'follower': 0
@@ -765,6 +761,7 @@ class PatchUserIDTestCase(TestCase):
             'user_id': 'user2_ID',
             'bio': 'I am User 1.',
             'birth_date': '2002-11-15',
+            'tweets': [],
             'tweets_num': 0,
             'following': 0,
             'follower': 0

--- a/clone_twitter/user/views.py
+++ b/clone_twitter/user/views.py
@@ -419,3 +419,4 @@ class SearchPeopleView(APIView, UserListPagination):
 
         serializer = UserInfoSerializer(sorted_queryset, many=True, context={'request': request})
         return Response(serializer.data, status=status.HTTP_200_OK)
+        

--- a/clone_twitter/user/views.py
+++ b/clone_twitter/user/views.py
@@ -202,7 +202,7 @@ class UserInfoViewSet(viewsets.GenericViewSet):
     def id(self, request):
         user = request.user
 
-        serializer = self.get_serializer(user, data=request.data, partial=True)
+        serializer = self.get_serializer(user, data=request.data, partial=True, context={'request': request})
         if serializer.is_valid(raise_exception=True):
             serializer.save()
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/clone_twitter/user/views.py
+++ b/clone_twitter/user/views.py
@@ -1,4 +1,6 @@
 import json
+from multiprocessing.sharedctypes import Value
+from django.test import tag
 import rest_framework.pagination
 
 import user.paginations
@@ -403,15 +405,26 @@ class SearchPeopleView(APIView, UserListPagination):
     def get(self, request):
         if not request.query_params:
             return Response(status=status.HTTP_400_BAD_REQUEST, data={'message': 'no query provided'})
-        search_keywords = request.query_params['query'].split()
+        search_keywords = request.query_params['query'].split() 
+        tag_keywords = ['']
+        
+
+        for k in range(len(search_keywords)):
+            if search_keywords[k][0] == '@':
+                search_keywords[k] = search_keywords[k][1:]
+                tag_keywords.append(search_keywords[k])
+
 
         sorted_queryset = \
             User.objects.all() \
-            .annotate(num_keywords_included=sum([Case(When(Q(username__icontains=keyword) | Q(user_id__icontains=keyword) | Q(bio__icontains=keyword), then=1), default=0) for keyword in search_keywords]), num_keywords_in_username=sum([Case(When(Q(username__icontains=keyword), then=1), default=0) for keyword in search_keywords]), num_followers=Count('following')) \
+            .annotate(num_keywords_included=sum([Case(When(Q(username__icontains=keyword) | Q(user_id__icontains=keyword) | Q(bio__icontains=keyword), then=1), default=0) for keyword in search_keywords]),
+                num_keywords_in_username=sum([Case(When(Q(username__icontains=keyword), then=1), default=0) for keyword in search_keywords]),
+                is_tag_keyword=sum([Case(When(user_id=keyword, then=1), default=0) for keyword in tag_keywords]),
+                num_followers=Count('following')) \
             .filter(num_keywords_included__gte=1) \
-            .order_by('-num_keywords_in_username', '-num_keywords_included', '-num_followers')
+            .order_by('-is_tag_keyword', '-num_keywords_in_username', '-num_keywords_included', '-num_followers')
 
-        page = self.paginate_queryset(sorted_queryset)
+        page = self.paginate_queryset(sorted_queryset, request)
 
         if page is not None:
             serializer = UserInfoSerializer(page, many=True, context={'request': request})
@@ -419,4 +432,3 @@ class SearchPeopleView(APIView, UserListPagination):
 
         serializer = UserInfoSerializer(sorted_queryset, many=True, context={'request': request})
         return Response(serializer.data, status=status.HTTP_200_OK)
-        


### PR DESCRIPTION
`GET api/v1/user/{user_id}/`로 얻는 정보 중 user의 'tweets' 필드를 직접 작성한 트윗을 모은 'tweets_written'과 리트윗을 모은 'tweets_retweeted'로 나누었습니다.