### PR TITLE
Feat: Extend Search People API to Support Tag

### DIFF
--- a/clone_twitter/user/tests.py
+++ b/clone_twitter/user/tests.py
@@ -850,9 +850,9 @@ class GetSearchPeopleTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
 
-        user_id_list = ['test0', 'test1', 'test2', 'test3', 'test4', 'test5', 'test6', 'test7', 'test8ee', 'test9']
-        username_list = ['f', 'f', 'f', 'aa', 'aabb', 'aabbcc', 'aabbcc', 'aabbcc', 'aabbcc', 'aabbcc']
-        bio_list = ['', 'aa', 'aabbcc', 'mol', '?', 'ru', '', 'aaccdd', 'aa', 'aabbccddee']
+        user_id_list = ['test0', 'test1', 'test2', 'test3', 'test4', 'test5', 'test6', 'test7', 'test8ee', 'test9', 'kk', 'tt']
+        username_list = ['f', 'aa', 'f', 'aa', 'aabb', 'aabbcc', 'aabbcc', 'aabbcc', 'aabbcc', 'aabbcc', 'ee', 'gg']
+        bio_list = ['', '', 'aabbcc', 'mol', '?', 'ru', '', 'aaccdd', 'aa', 'aabbccddee', '', '']
         follow_relation = [(0,8), (1,8), (0,6)]
         
         cls.users = [
@@ -881,5 +881,17 @@ class GetSearchPeopleTestCase(TestCase):
             HTTP_AUTHORIZATION=self.tokens[0])
         
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(list(map(lambda x:x['user_id'], response.json())),
-        ['test9', 'test8ee', 'test7', 'test6', 'test5', 'test4', 'test3', 'test2', 'test1'])
+        self.assertEqual(list(map(lambda x:x['user_id'], response.json()['results'])),
+        ['test9', 'test8ee', 'test7', 'test6', 'test5', 'test4', 'test3', 'test2', 'kk', 'test1'])
+
+    # Several Keywords with those including @ sign
+    def test_get_search_people_with_atsign(self):
+        response = self.client.get(                            
+            '/api/v1/search/people/',
+            {'query': 'bb cc  aa dd @kk @tt ee'},
+            content_type='application/json',
+            HTTP_AUTHORIZATION=self.tokens[0])
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(list(map(lambda x:x['user_id'], response.json()['results'])),
+        ['kk', 'tt', 'test9', 'test8ee', 'test7', 'test6', 'test5', 'test4', 'test3', 'test2', 'test1'])

--- a/clone_twitter/user/views.py
+++ b/clone_twitter/user/views.py
@@ -1,4 +1,6 @@
 import json
+from multiprocessing.sharedctypes import Value
+from django.test import tag
 import rest_framework.pagination
 
 import user.paginations
@@ -403,15 +405,26 @@ class SearchPeopleView(APIView, UserListPagination):
     def get(self, request):
         if not request.query_params:
             return Response(status=status.HTTP_400_BAD_REQUEST, data={'message': 'no query provided'})
-        search_keywords = request.query_params['query'].split()
+        search_keywords = request.query_params['query'].split() 
+        tag_keywords = ['']
+        
+
+        for k in range(len(search_keywords)):
+            if search_keywords[k][0] == '@':
+                search_keywords[k] = search_keywords[k][1:]
+                tag_keywords.append(search_keywords[k])
+
 
         sorted_queryset = \
             User.objects.all() \
-            .annotate(num_keywords_included=sum([Case(When(Q(username__icontains=keyword) | Q(user_id__icontains=keyword) | Q(bio__icontains=keyword), then=1), default=0) for keyword in search_keywords]), num_keywords_in_username=sum([Case(When(Q(username__icontains=keyword), then=1), default=0) for keyword in search_keywords]), num_followers=Count('following')) \
+            .annotate(num_keywords_included=sum([Case(When(Q(username__icontains=keyword) | Q(user_id__icontains=keyword) | Q(bio__icontains=keyword), then=1), default=0) for keyword in search_keywords]),
+                num_keywords_in_username=sum([Case(When(Q(username__icontains=keyword), then=1), default=0) for keyword in search_keywords]),
+                is_tag_keyword=sum([Case(When(user_id=keyword, then=1), default=0) for keyword in tag_keywords]),
+                num_followers=Count('following')) \
             .filter(num_keywords_included__gte=1) \
-            .order_by('-num_keywords_in_username', '-num_keywords_included', '-num_followers')
+            .order_by('-is_tag_keyword', '-num_keywords_in_username', '-num_keywords_included', '-num_followers')
 
-        page = self.paginate_queryset(sorted_queryset)
+        page = self.paginate_queryset(sorted_queryset, request)
 
         if page is not None:
             serializer = UserInfoSerializer(page, many=True, context={'request': request})
@@ -419,4 +432,3 @@ class SearchPeopleView(APIView, UserListPagination):
 
         serializer = UserInfoSerializer(sorted_queryset, many=True, context={'request': request})
         return Response(serializer.data, status=status.HTTP_200_OK)
-        


### PR DESCRIPTION
유저 검색 API인 `GET api/v1/search/people/`에 @를 앞에 단 키워드를 포함해 검색하는 경우 해당 키워드와 완전히 같은 user_id를 가진 유저가 먼저 표시되도록 기능을 확장했습니다. 이전 PR이 merge되지 않은 상태로 추가 작업한 것이라 부득이하게 base를 이전 PR의 branch로 하였으니, 두 PR 확인하실 경우 이 PR부터 먼저 merge해야 할 것 같습니다!