### PR TITLE
Chore: Change Setting to Support Unicode

### DIFF
--- a/clone_twitter/twitter/settings.py
+++ b/clone_twitter/twitter/settings.py
@@ -123,7 +123,11 @@ DATABASES = {
         'PASSWORD': DB_PASSWORD,
         'TEST': {
             'NAME': 'test_twitter_backend',
-        }
+        },
+        'OPTIONS': {
+            'charset': 'utf8mb4',
+            'use_unicode': True, 
+        },
     }
 }
 

--- a/clone_twitter/user/serializers.py
+++ b/clone_twitter/user/serializers.py
@@ -349,6 +349,7 @@ class UserInfoSerializer(serializers.ModelSerializer):
 
     def update(self, instance, validated_data):
         instance.user_id = validated_data.get('user_id', instance.user_id)
+        instance.save()
         return instance
 
       


### PR DESCRIPTION
DB에서 이모지(😄 등)가 깨지는 버그가 있었는데 이를 수정하기 위해 DB와 백엔드에서 unicode를 사용하도록 설정을 수정했습니다.  서버에 있는 mysql 설정은 이미 바꿔놓은 상태입니다! 성공적으로 작동하는지 확인하려면 프론트랑 통신을 해 봐야 되겠네요