### PR TITLE
Fix: Add Missing Save when Changing user_id

### DIFF
--- a/clone_twitter/user/serializers.py
+++ b/clone_twitter/user/serializers.py
@@ -349,6 +349,7 @@ class UserInfoSerializer(serializers.ModelSerializer):
 
     def update(self, instance, validated_data):
         instance.user_id = validated_data.get('user_id', instance.user_id)
+        instance.save()
         return instance
 
       


### PR DESCRIPTION
user_id를 변경하는 API에서 save()가 누락되어서 응답은 제대로 도착해도 실제로 유저명이 바뀌진 않고 있었네요.. 추가하였습니다! 이것 또한 프론트에서 다시 테스트해봐야 할 것 같습니다