### PR TITLE
Fix: Split Search Keywords in Proper Way

### DIFF
--- a/clone_twitter/tweet/views.py
+++ b/clone_twitter/tweet/views.py
@@ -1,3 +1,4 @@
+import re
 from user.models import User
 import tweet.paginations
 from django.db import IntegrityError
@@ -216,7 +217,8 @@ class TweetSearchViewSet(viewsets.GenericViewSet):
     def get_top(self, request):
         if not request.query_params:
             return Response(status=status.HTTP_400_BAD_REQUEST, data={'message': 'no query provided'})
-        search_keywords = request.query_params['query'].split()
+        search_keywords = request.query_params['query']
+        search_keywords = re.split('%%20|+', search_keywords)
 
         sorted_queryset = \
             Tweet.objects.all() \
@@ -239,7 +241,8 @@ class TweetSearchViewSet(viewsets.GenericViewSet):
     def get_latest(self, request):
         if not request.query_params:
             return Response(status=status.HTTP_400_BAD_REQUEST, data={'message': 'no query provided'})
-        search_keywords = request.query_params['query'].split()
+        search_keywords = request.query_params['query']
+        search_keywords = re.split('%%20|+', search_keywords)
 
         sorted_queryset = \
             Tweet.objects.all() \

--- a/clone_twitter/user/views.py
+++ b/clone_twitter/user/views.py
@@ -1,5 +1,6 @@
 import json
 from multiprocessing.sharedctypes import Value
+import re
 from django.test import tag
 
 import user.paginations
@@ -478,7 +479,8 @@ class SearchPeopleView(APIView, UserListPagination):
     def get(self, request):
         if not request.query_params:
             return Response(status=status.HTTP_400_BAD_REQUEST, data={'message': 'no query provided'})
-        search_keywords = request.query_params['query'].split() 
+        search_keywords = request.query_params['query']
+        search_keywords = re.split('%%20|+', search_keywords) 
         tag_keywords = ['']
         
 


### PR DESCRIPTION
기존의 Search API를 프론트에서 테스트해본 결과 여러 단어가 띄어쓰기를 입력한 경우 제대로 검색이 되지 않았습니다. 이는 검색어가 백으로 전달될 때 띄어쓰기가 `+`  또는 `%20`으로 인코딩되어 전달되기 때문입니다. 이 부분을 고려해 검색 API를 수정했습니다.